### PR TITLE
Deferred execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ geeSEBAL_Image=Image(Image_ID)
 from etbrasil.geesebal import Collection
 
 #inputs= init Year, init Month, init dat, end Year, end Month, end day, Cloud Cover
-geeSEBAL_Collection=Collection(2000,1,1,2010,5,6,15)
+geeSEBAL_Collection=Collection(2000,1,1,2010,5,6,15,path=221,row=71)
 ```
 ### TimeSeries
 ```python
@@ -55,7 +55,7 @@ from etbrasil.eesebal import TimeSeries
 #inputs= init Year, init Month, init dat, end Year, end Month, end day, Cloud Cover,ee.Geometry.Point
 point=ee.Geometry.Point([-50.161317, -9.824870])
 
-geeSEBAL_Collection=TimeSeries(2000,1,1,2010,5,6,15,point)
+geeSEBAL_Collection=TimeSeries(2000,1,1,2010,5,6,15, coordinate=point)
 ```
 
 ## What is SEBAL?

--- a/etbrasil/geesebal/__init__.py
+++ b/etbrasil/geesebal/__init__.py
@@ -1,5 +1,5 @@
 from .image import Image
 from .collection import Collection
-from .timeseries import TimeSeries
+from .timeseries import TimeSeries, TimeSeriesAsync
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/etbrasil/geesebal/collection.py
+++ b/etbrasil/geesebal/collection.py
@@ -24,11 +24,7 @@ from datetime import date
 from .landsatcollection import (fexp_landsat_5PathRow,fexp_landsat_7PathRow, fexp_landsat_8PathRow,
 fexp_trad_5PathRow, fexp_trad_7PathRow, fexp_trad_8PathRow)
 from .masks import (f_cloudMaskL457_SR,f_cloudMaskL8_SR,f_albedoL5L7,f_albedoL8)
-from .meteorology import get_meteorology
-from .tools import (fexp_spec_ind, fexp_lst_export,fexp_radlong_up, LST_DEM_correction,
-fexp_radshort_down, fexp_radlong_down, fexp_radbalance, fexp_soil_heat,fexp_sensible_heat_flux)
-from .endmembers import fexp_cold_pixel, fexp_hot_pixel
-from .evapotranspiration import fexp_et
+from .image import sebal
 
 #COLLECTION FUNCTION
 class Collection():
@@ -61,7 +57,7 @@ class Collection():
         self.n_search_days=self.n_search_days.days
         self.end_date = self.start_date.advance(self.n_search_days, 'day')
 
-        #COLLECTIONS    
+        #COLLECTIONS 
         self.collection_l5=fexp_landsat_5PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
         self.collection_l7=fexp_landsat_7PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
         self.collection_l8=fexp_landsat_8PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
@@ -75,7 +71,7 @@ class Collection():
         self.sceneListL7 = self.collection_l7.aggregate_array('system:index')
         self.sceneListL8 = self.collection_l8.aggregate_array('system:index')
 
-        #ALBEDO AND MASKS   
+        #ALBEDO AND MASKS    
         self.collection_l5 = self.collection_l5.map(f_albedoL5L7).map(f_cloudMaskL457_SR)   
         self.collection_l7 = self.collection_l7.map(f_albedoL5L7).map(f_cloudMaskL457_SR)
         self.collection_l8= self.collection_l8.map(f_albedoL8).map(f_cloudMaskL8_SR)
@@ -94,178 +90,10 @@ class Collection():
         
         self.collection = join_by_landsat_index.map(get_img)  
 
-        self.CollectionList=self.collection.sort("system:time_start").aggregate_array('system:index').getInfo()
-        self.CollectionList_image = self.collection.aggregate_array('system:index').getInfo()
-        self.count = self.collection.size().getInfo()
+        # Map the sebal algorithm to the image collection
+        sebal_algorithm = sebal(NDVI_cold=NDVI_cold, Ts_cold=Ts_cold, NDVI_hot=NDVI_hot, Ts_hot = Ts_hot)
+        self.collection_ET = self.collection.map(sebal_algorithm)
 
-        #PRINT NUMBER OF SCENES
-        print("Number of scenes: ", self.count)
-
-        n =0
-        k=0
-
-        #====== ITERATIVE PROCESS ======#
-        #FOR EACH IMAGE ON THE LIST
-        #ESTIMATE ET DAILY IMAGE
-        while n < self.count:
-            #GET IMAGE
-            self.image= self.collection.filterMetadata('system:index','equals',self.CollectionList[n]).first()
-            self.image=ee.Image(self.image)
-
-            #PRINT ID
-            print(self.image.get('LANDSAT_ID').getInfo())
-
-            #GET INFORMATIONS FROM IMAGE
-            self._index=self.image.get('system:index')
-            self.cloud_cover=self.image.get('CLOUD_COVER')
-            self.LANDSAT_ID=self.image.get('LANDSAT_ID').getInfo()
-            self.landsat_version=self.image.get('SATELLITE').getInfo()
-            self.zenith_angle=self.image.get("SOLAR_ZENITH_ANGLE").getInfo()
-            self.azimuth_angle=self.image.get('SOLAR_AZIMUTH_ANGLE')
-            self.time_start=self.image.get('system:time_start')
-            self._date=ee.Date(self.time_start)
-            self._year=ee.Number(self._date.get('year'))
-            self._month=ee.Number(self._date.get('month'))
-            self._day=ee.Number(self._date.get('month'))
-            self._hour=ee.Number(self._date.get('hour'))
-            self._minuts = ee.Number(self._date.get('minutes'))
-            self.crs = self.image.projection().crs()
-            self.transform = ee.List(ee.Dictionary(ee.Algorithms.Describe(self.image.projection())).get('transform'))
-            self.date_string=self._date.format('YYYY-MM-dd').getInfo()
-
-            #ENDMEMBERS
-            self.p_top_NDVI=ee.Number(NDVI_cold)
-            self.p_coldest_Ts=ee.Number(Ts_cold)
-            self.p_lowest_NDVI=ee.Number(NDVI_hot)
-            self.p_hottest_Ts=ee.Number(Ts_hot)
-
-
-            #MAKS
-            if self.landsat_version == 'LANDSAT_5':
-                 #self.image=self.image .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                 self.image_toa=ee.Image('LANDSAT/LT05/C01/T1/'+ self._index.getInfo())
-
-                 #GET CALIBRATED RADIANCE
-                 self.col_rad = ee.Algorithms.Landsat.calibratedRadiance(self.image_toa);
-                 self.col_rad = self.image.addBands(self.col_rad.select([5],["T_RAD"]))
-
-                 #CLOUD REMOTION
-                 self.image=ee.ImageCollection(self.image).map(f_cloudMaskL457_SR)
-
-                 #ALBEDO TASUMI ET AL. (2008)
-                 self.image=self.image.map(f_albedoL5L7)
-
-            elif self.landsat_version == 'LANDSAT_7':
-                #self.image=self.image .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                 self.image_toa=ee.Image('LANDSAT/LE07/C01/T1/'+ self.CollectionList[n][4:])
-
-                 #GET CALIBRATED RADIANCE
-                 self.col_rad = ee.Algorithms.Landsat.calibratedRadiance(self.image_toa);
-                 self.col_rad = self.image.addBands(self.col_rad.select([5],["T_RAD"]))
-
-                 #CLOUD REMOTION
-                 self.image=ee.ImageCollection(self.image).map(f_cloudMaskL457_SR)
-
-                 #ALBEDO TASUMI ET AL. (2008)
-                 self.image=self.image.map(f_albedoL5L7)
-
-            else:
-                #self.image = self.select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
-                self.image_toa=ee.Image('LANDSAT/LC08/C01/T1/'+self._index.getInfo())
-
-                #GET CALIBRATED RADIANCE
-                self.col_rad = ee.Algorithms.Landsat.calibratedRadiance(self.image_toa)
-                self.col_rad = self.image.addBands(self.col_rad.select([9],["T_RAD"]))
-
-                #CLOUD REMOTION
-                self.image=ee.ImageCollection(self.image).map(f_cloudMaskL8_SR)
-
-                #ALBEDO TASUMI ET AL. (2008) METHOD WITH KE ET AL. (2016) COEFFICIENTS
-                self.image=self.image.map(f_albedoL8)
-
-            #GEOMETRY
-            self.geometryReducer=self.image.geometry().bounds().getInfo()
-            self.geometry_download=self.geometryReducer['coordinates']
-            self.camada_clip=self.image.select('BRT').first()
-            self.sun_elevation=ee.Number(90).subtract(self.zenith_angle)
-
-            #METEOROLOGY PARAMETERS
-            col_meteorology= get_meteorology(self.image,self.time_start)
-
-            #AIR TEMPERATURE [C]
-            self.T_air = col_meteorology.select('AirT_G')
-
-            #WIND SPEED [M S-1]
-            self.ux= col_meteorology.select('ux_G')
-
-            #RELATIVE HUMIDITY (%)
-            self.UR = col_meteorology.select('RH_G')
-
-            #NET RADIATION 24H [W M-2]
-            self.Rn24hobs = col_meteorology.select('Rn24h_G')
-
-            #SRTM DATA ELEVATION
-            SRTM_ELEVATION ='USGS/SRTMGL1_003' # SRTM Data Elevation
-            self.srtm = ee.Image(SRTM_ELEVATION).clip(self.geometryReducer)
-            self.z_alt = self.srtm.select('elevation')
-
-            #TO AVOID ERRORS DURING THE PROCESS
-            try:
-                #GET IMAGE
-                self.image=self.image.first()
-
-                #SPECTRAL IMAGES (NDVI, EVI, SAVI, LAI, T_LST, e_0, e_NB, long, lat)
-                self.image=fexp_spec_ind(self.image)
-
-                #LAND SURFACE TEMPERATURE
-                #self.image =fexp_lst_export(self.image,self.col_rad,self.landsat_version,self.geometryReducer)
-                self.image=LST_DEM_correction(self.image, self.z_alt, self.T_air, self.UR,self.sun_elevation,self._hour,self._minuts)
-
-                #COLD PIXEL
-                self.d_cold_pixel=fexp_cold_pixel(self.image, self.geometryReducer, self.p_top_NDVI, self.p_coldest_Ts)
-
-                #COLD PIXEL NUMBER
-                self.n_Ts_cold = ee.Number(self.d_cold_pixel.get('temp').getInfo())
-
-                #INSTANTANEOUS OUTGOING LONG-WAVE RADIATION [W M-2]
-                self.image=fexp_radlong_up(self.image)
-
-                #INSTANTANEOUS INCOMING SHORT-WAVE RADIATION [W M-2]
-                self.image=fexp_radshort_down(self.image,self.z_alt,self.T_air,self.UR, self.sun_elevation)
-
-                #INSTANTANEOUS INCOMING LONGWAVE RADIATION [W M-2]
-                self.image=fexp_radlong_down(self.image, self.n_Ts_cold)
-
-                #INSTANTANEOUS NET RADIATON BALANCE [W M-2]
-                self.image=fexp_radbalance(self.image)
-
-                #SOIL HEAT FLUX (G) [W M-2]
-                self.image=fexp_soil_heat(self.image)
-
-                #HOT PIXEL
-                self.d_hot_pixel=fexp_hot_pixel(self.image, self.geometryReducer,self.p_lowest_NDVI, self.p_hottest_Ts)
-                #SENSIBLE HEAT FLUX (H) [W M-2]
-                self.image=fexp_sensible_heat_flux(self.image, self.ux, self.UR,self.Rn24hobs,self.n_Ts_cold,
-                                                   self.d_hot_pixel, self.date_string,self.geometryReducer)
-
-                #DAILY EVAPOTRANSPIRATION (ET_24H) [MM DAY-1]
-                self.image=fexp_et(self.image,self.Rn24hobs)
-
-
-                self.NAME_FINAL=self.LANDSAT_ID[:5]+self.LANDSAT_ID[10:17]+self.LANDSAT_ID[17:25]
-                self.ET_daily=self.image.select(['ET_24h'],[self.NAME_FINAL])
-
-                if k ==0:
-                    self.Collection_ET=self.ET_daily
-                else:
-                    self.Collection_ET=self.Collection_ET.addBands(self.ET_daily)
-                k=k+1
-            except:
-                # ERRORS CAN OCCUR WHEN:
-                # - THERE IS NO METEOROLOGICAL INFORMATION.
-                # - ET RETURN NULL IF AT THE POINT WAS APPLIED MASK CLOUD.
-                # - CONEECTION ISSUES.
-                # - SEBAL DOESN'T FIND A REASONABLE LINEAR RELATIONSHIP (dT).
-
-                print('Error.')
-            n=n+1
+        self.CollectionList=self.collection.sort("system:time_start").aggregate_array('system:index')
+        self.CollectionList_image = self.collection.aggregate_array('system:index')
+        self.count = self.collection.size()

--- a/etbrasil/geesebal/collection.py
+++ b/etbrasil/geesebal/collection.py
@@ -21,8 +21,8 @@ import ee
 from datetime import date
 
 #FOLDERS
-from .landsatcollection import (fexp_landsat_5PathRow,fexp_landsat_7PathRow, fexp_landsat_8PathRow,
-fexp_trad_5PathRow, fexp_trad_7PathRow, fexp_trad_8PathRow)
+from .landsatcollection import (fexp_landsat_5,fexp_landsat_7, fexp_landsat_8,
+fexp_trad_5, fexp_trad_7, fexp_trad_8)
 from .masks import (f_cloudMaskL457_SR,f_cloudMaskL8_SR,f_albedoL5L7,f_albedoL8)
 from .image import sebal
 
@@ -39,17 +39,24 @@ class Collection():
                  month_e,
                  day_e,
                  cloud_cover,
-                 path,
-                 row,
+                 path=None,
+                 row=None,
+                 coordinate=None,
                  NDVI_cold=5,
                  Ts_cold=20,
                  NDVI_hot=10,
                  Ts_hot=20, 
                  max_iterations=15):
 
+        if not any([all([path,row]),coordinate]):
+            raise ValueError("Either coordinate or a combination of path/row should be specified.")
+        # ^ Otherwise user could request too many Landsat images by accident. 
+        spatial_filters = {"n_path":path, "n_row":row, "coordinate":coordinate}
+
         #INFORMATIONS
         self.path=path
         self.row=row
+        self.coordiate=coordinate
         self.cloud_cover=cloud_cover
         self.start_date = ee.Date.fromYMD(year_i,month_i,day_i)
         self.i_date=date(year_i,month_i,day_i)
@@ -60,12 +67,12 @@ class Collection():
         self.max_iterations = max_iterations
 
         #COLLECTIONS 
-        self.collection_l5=fexp_landsat_5PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
-        self.collection_l7=fexp_landsat_7PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
-        self.collection_l8=fexp_landsat_8PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
-        rad_l5 = fexp_trad_5PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
-        rad_l7 = fexp_trad_7PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
-        rad_l8 = fexp_trad_8PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
+        self.collection_l5=fexp_landsat_5(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
+        self.collection_l7=fexp_landsat_7(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
+        self.collection_l8=fexp_landsat_8(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
+        rad_l5 = fexp_trad_5(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
+        rad_l7 = fexp_trad_7(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
+        rad_l8 = fexp_trad_8(self.start_date, self.end_date, self.cloud_cover, **spatial_filters)
         rad_collection = rad_l5.merge(rad_l7).merge(rad_l8)
 
         #LIST OF IMAGES

--- a/etbrasil/geesebal/collection.py
+++ b/etbrasil/geesebal/collection.py
@@ -56,7 +56,7 @@ class Collection():
         #INFORMATIONS
         self.path=path
         self.row=row
-        self.coordiate=coordinate
+        self.coordinate=coordinate
         self.cloud_cover=cloud_cover
         self.start_date = ee.Date.fromYMD(year_i,month_i,day_i)
         self.i_date=date(year_i,month_i,day_i)

--- a/etbrasil/geesebal/collection.py
+++ b/etbrasil/geesebal/collection.py
@@ -44,7 +44,8 @@ class Collection():
                  NDVI_cold=5,
                  Ts_cold=20,
                  NDVI_hot=10,
-                 Ts_hot=20):
+                 Ts_hot=20, 
+                 max_iterations=15):
 
         #INFORMATIONS
         self.path=path
@@ -56,6 +57,7 @@ class Collection():
         self.n_search_days=self.end_date - self.i_date
         self.n_search_days=self.n_search_days.days
         self.end_date = self.start_date.advance(self.n_search_days, 'day')
+        self.max_iterations = max_iterations
 
         #COLLECTIONS 
         self.collection_l5=fexp_landsat_5PathRow(self.start_date, self.end_date, self.path, self.row, self.cloud_cover)
@@ -91,7 +93,9 @@ class Collection():
         self.collection = join_by_landsat_index.map(get_img)  
 
         # Map the sebal algorithm to the image collection
-        sebal_algorithm = sebal(NDVI_cold=NDVI_cold, Ts_cold=Ts_cold, NDVI_hot=NDVI_hot, Ts_hot = Ts_hot)
+        sebal_algorithm = sebal(NDVI_cold=NDVI_cold, Ts_cold=Ts_cold, 
+                                NDVI_hot=NDVI_hot, Ts_hot = Ts_hot,
+                                max_iterations=max_iterations)
         self.collection_ET = self.collection.map(sebal_algorithm)
 
         self.CollectionList=self.collection.sort("system:time_start").aggregate_array('system:index')

--- a/etbrasil/geesebal/image.py
+++ b/etbrasil/geesebal/image.py
@@ -92,10 +92,22 @@ class Image():
         col_rad = l8_rad.merge(l7_rad).merge(l5_rad)
         self.col_rad = self.image.addBands(col_rad.first())
 
+        #RENAME LANDSAT BANDS
+        band_numbers = ee.Dictionary({
+            "LANDSAT_5": ee.List([0,1,2,3,4,5,6,9]),
+            "LANDSAT_7": ee.List([0,1,2,3,4,5,6,9]), 
+            "LANDSAT_8": ee.List([0,1,2,3,4,5,6,7,10])})
+        band_names = ee.Dictionary({
+            "LANDSAT_5": ee.List(["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"]),
+            "LANDSAT_7": ee.List(["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"]), 
+            "LANDSAT_8": ee.List(["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])})
+
+        self.image = self.image.select(
+            band_numbers.get(self.image.get("SATELLITE")), 
+            band_names.get(self.image.get("SATELLITE")))
+
         #LANDSAT IMAGE
         if self.landsat_version == 'LANDSAT_5':
-             self.image=self.image.select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-
          #CLOUD REMOTION
              self.image=ee.ImageCollection(self.image).map(f_cloudMaskL457_SR)
 
@@ -103,8 +115,6 @@ class Image():
              self.image=self.image.map(f_albedoL5L7)
 
         elif self.landsat_version == 'LANDSAT_7':
-             self.image=self.image.select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-
          #CLOUD REMOVAL
              self.image=ee.ImageCollection(self.image).map(f_cloudMaskL457_SR)
 
@@ -112,8 +122,6 @@ class Image():
              self.image=self.image.map(f_albedoL5L7)
 
         else:
-            self.image = self.image.select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
-
          #CLOUD REMOVAL
             self.image=ee.ImageCollection(self.image).map(f_cloudMaskL8_SR)
 

--- a/etbrasil/geesebal/image.py
+++ b/etbrasil/geesebal/image.py
@@ -47,7 +47,7 @@ class Image():
         self.image = ee.Image(image)
         self._index=self.image.get('system:index')
         self.cloud_cover=self.image.get('CLOUD_COVER')
-        self.LANDSAT_ID=self.image.get('LANDSAT_ID')#.getInfo()
+        self.LANDSAT_ID=self.image.get('LANDSAT_ID')
         self.landsat_version= ee.String(self.image.get('SATELLITE'))
         self.azimuth_angle=self.image.get('SOLAR_ZENITH_ANGLE')
         self.time_start=self.image.get('system:time_start')
@@ -117,8 +117,7 @@ class Image():
         )
 
         #GEOMETRY
-        self.geometryReducer=self.image.geometry().bounds().getInfo()
-        self.geometry_download=self.geometryReducer['coordinates']
+        self.geometryReducer=self.image.geometry().bounds()
         self.camada_clip=self.image.select('BRT').first()
 
         self.sun_elevation=ee.Number(90).subtract(self.azimuth_angle)
@@ -156,7 +155,7 @@ class Image():
         self.d_cold_pixel=fexp_cold_pixel(self.image, self.geometryReducer, self.p_top_NDVI, self.p_coldest_Ts)
 
         #COLD PIXEL NUMBER
-        self.n_Ts_cold = ee.Number(self.d_cold_pixel.get('temp').getInfo())
+        self.n_Ts_cold = ee.Number(self.d_cold_pixel.get('temp'))
 
         #INSTANTANEOUS OUTGOING LONG-WAVE RADIATION [W M-2]
         self.image=fexp_radlong_up(self.image)
@@ -182,6 +181,3 @@ class Image():
 
         #DAILY EVAPOTRANSPIRATION (ET_24H) [MM DAY-1]
         self.image=fexp_et(self.image,self.Rn24hobs)
-
-        #self.NAME_FINAL=self.LANDSAT_ID[:5]+self.LANDSAT_ID[10:17]+self.LANDSAT_ID[17:25]
-        #self.image=self.image.addBands([self.image.select('ET_24h').rename(self.NAME_FINAL)])

--- a/etbrasil/geesebal/image.py
+++ b/etbrasil/geesebal/image.py
@@ -123,24 +123,24 @@ class Image():
         self.sun_elevation=ee.Number(90).subtract(self.azimuth_angle)
 
         #METEOROLOGY PARAMETERS
-        col_meteorology= get_meteorology(self.image,self.time_start);
+        col_meteorology= get_meteorology(self.image,self.time_start)
 
         #AIR TEMPERATURE [C]
-        self.T_air = col_meteorology.select('AirT_G');
+        self.T_air = col_meteorology.select('AirT_G')
 
         #WIND SPEED [M S-1]
-        self.ux= col_meteorology.select('ux_G');
+        self.ux= col_meteorology.select('ux_G')
 
         #RELATIVE HUMIDITY [%]
-        self.UR = col_meteorology.select('RH_G');
+        self.UR = col_meteorology.select('RH_G')
 
         #NET RADIATION 24H [W M-2]
-        self.Rn24hobs = col_meteorology.select('Rn24h_G');
+        self.Rn24hobs = col_meteorology.select('Rn24h_G')
 
         #SRTM DATA ELEVATION
         SRTM_ELEVATION ='USGS/SRTMGL1_003'
-        self.srtm = ee.Image(SRTM_ELEVATION).clip(self.geometryReducer);
-        self.z_alt = self.srtm.select('elevation');
+        self.srtm = ee.Image(SRTM_ELEVATION).clip(self.geometryReducer)
+        self.z_alt = self.srtm.select('elevation')
 
         #GET IMAGE
         self.image=self.image.first()

--- a/etbrasil/geesebal/landsatcollection.py
+++ b/etbrasil/geesebal/landsatcollection.py
@@ -27,103 +27,62 @@ def set_landsat_index(img):
        by merging or joining collections"""
       return img.set({"LANDSAT_INDEX": img.get("system:index")})
 
-# Filter collection by path, row, and cloud cover
-def fexp_filter_PathRow(collection, start_date, end_date, n_path, n_row, th_cloud_cover):
-    return (collection
-            .filterDate(start_date, end_date)
-            .filterMetadata('WRS_PATH', 'equals', n_path)
-            .filterMetadata('WRS_ROW', 'equals', n_row)
+# Filter collection by path, row, coordinate, and cloud cover
+def fexp_collection_filter(collection, start_date, end_date, th_cloud_cover, 
+    n_path=None, n_row=None, coordinate = None):
+    collection = (collection.filterDate(start_date, end_date)
             .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
-            )
+    )
+    if n_path: collection = collection.filterMetadata('WRS_PATH', 'equals', n_path)
+    if n_row: collection = collection.filterMetadata('WRS_ROW', 'equals', n_row)
+    if coordinate: collection = collection.filterBounds(coordinate)
+    return collection
 
-# GET T_RAD band from T1 products by PATH ROW
-def fexp_trad_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
-    return (fexp_filter_PathRow(
+# GET T_RAD band from T1 products  
+def fexp_trad_8(start_date,end_date,th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
         ee.ImageCollection('LANDSAT/LC08/C01/T1'),
-        start_date, end_date, n_path, n_row, th_cloud_cover)
+        start_date, end_date, th_cloud_cover, **kwargs)
             .map(ee.Algorithms.Landsat.calibratedRadiance)
             .map(set_landsat_index)
             .select([9],["T_RAD"]))
 
-def fexp_trad_7PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
-    return (fexp_filter_PathRow(
+def fexp_trad_7(start_date,end_date,th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
         ee.ImageCollection('LANDSAT/LE07/C01/T1'),
-        start_date, end_date, n_path, n_row, th_cloud_cover)
+        start_date, end_date, th_cloud_cover, **kwargs)
             .map(ee.Algorithms.Landsat.calibratedRadiance)
             .map(set_landsat_index)
             .select([5],["T_RAD"]))
 
-def fexp_trad_5PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
-    return (fexp_filter_PathRow(
+def fexp_trad_5(start_date,end_date,th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
         ee.ImageCollection('LANDSAT/LT05/C01/T1'),
-        start_date, end_date, n_path, n_row, th_cloud_cover)
+        start_date, end_date, th_cloud_cover, **kwargs)
             .map(ee.Algorithms.Landsat.calibratedRadiance)
             .map(set_landsat_index)
             .select([5],["T_RAD"]))
 
-#GET LANDSAT 8 COLLECTIONS BY PATH ROW
-def fexp_landsat_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
-    col_SR_L8 =(ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterMetadata('WRS_PATH', 'equals', n_path)
-                        .filterMetadata('WRS_ROW', 'equals', n_row)
-                        .select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
-                        .map(set_landsat_index))
-    return col_SR_L8;
+#GET LANDSAT 8 COLLECTION
+def fexp_landsat_8(start_date,end_date, th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
+        ee.ImageCollection('LANDSAT/LC08/C01/T1_SR'),
+        start_date, end_date, th_cloud_cover, **kwargs)
+        .select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
+        .map(set_landsat_index))
 
-#GET LANDSAT 7 COLLECTIONS BY PATH ROW
-def fexp_landsat_7PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
+#GET LANDSAT 7 COLLECTION
+def fexp_landsat_7(start_date,end_date, th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
+        ee.ImageCollection('LANDSAT/LE07/C01/T1_SR'),
+        start_date, end_date, th_cloud_cover, **kwargs)
+        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
+        .map(set_landsat_index))
 
-    col_SR_L7 =(ee.ImageCollection('LANDSAT/LE07/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterMetadata('WRS_PATH', 'equals', n_path)
-                        .filterMetadata('WRS_ROW', 'equals', n_row)
-                        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
-                        .map(set_landsat_index))
-
-    return col_SR_L7;
-
-#GET LANDSAT 5 COLLECTIONS BY PATH ROW
-def fexp_landsat_5PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
-    col_SR_L5 =(ee.ImageCollection('LANDSAT/LT05/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterMetadata('WRS_PATH', 'equals', n_path)
-                        .filterMetadata('WRS_ROW', 'equals', n_row)
-                        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
-                        .map(set_landsat_index))
-
-    return col_SR_L5;
-
-#GET LANDSAT 7 COLLECTIONS BY COORDINATE
-def fexp_landsat_7Coordinate(start_date,end_date,coordinate,th_cloud_cover):
-
-    col_SR_L7 =(ee.ImageCollection('LANDSAT/LE07/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterBounds(coordinate)
-                        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
-
-
-    return col_SR_L7;
-
-#GET LANDSAT 8 COLLECTIONS BY COORDINATE
-def fexp_landsat_8Coordinate(start_date,end_date,coordinate,th_cloud_cover):
-    col_SR_L8 =(ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterBounds(coordinate)
-                        .select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
-    return col_SR_L8;
-
-#GET LANDSAT 5 COLLECTIONS BY COORDINATE
-def fexp_landsat_5Coordinate(start_date,end_date,coordinate,th_cloud_cover):
-    col_SR_L5 =(ee.ImageCollection('LANDSAT/LT05/C01/T1_SR')
-                        .filterDate(start_date, end_date)
-                        .filterBounds(coordinate)
-                        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
-
-    return col_SR_L5;
+#GET LANDSAT 5 COLLECTION
+def fexp_landsat_5(start_date,end_date, th_cloud_cover, **kwargs):
+    return (fexp_collection_filter(
+        ee.ImageCollection('LANDSAT/LT05/C01/T1_SR'),
+        start_date, end_date, th_cloud_cover, **kwargs)
+        .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
+        .map(set_landsat_index))

--- a/etbrasil/geesebal/landsatcollection.py
+++ b/etbrasil/geesebal/landsatcollection.py
@@ -22,6 +22,11 @@ import ee
 #SURFACE REFLECTANCE
 #ATMOSPHERICALLY CORRECTED
 
+def set_landsat_index(img):
+      """Keeps system:index as LANDSAT_INDEX so that it doesn't get lost
+       by merging or joining collections"""
+      return img.set({"LANDSAT_INDEX": img.get("system:index")})
+
 #GET LANDSAT 8 COLLECTIONS BY PATH ROW
 def fexp_landsat_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
     col_SR_L8 =(ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')
@@ -29,7 +34,8 @@ def fexp_landsat_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
                         .filterMetadata('WRS_PATH', 'equals', n_path)
                         .filterMetadata('WRS_ROW', 'equals', n_row)
                         .select([0,1,2,3,4,5,6,7,10],["UB","B","GR","R","NIR","SWIR_1","SWIR_2","BRT","pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
+                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
+                        .map(set_landsat_index))
     return col_SR_L8;
 
 #GET LANDSAT 7 COLLECTIONS BY PATH ROW
@@ -40,8 +46,8 @@ def fexp_landsat_7PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
                         .filterMetadata('WRS_PATH', 'equals', n_path)
                         .filterMetadata('WRS_ROW', 'equals', n_row)
                         .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
-
+                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
+                        .map(set_landsat_index))
 
     return col_SR_L7;
 
@@ -52,7 +58,8 @@ def fexp_landsat_5PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
                         .filterMetadata('WRS_PATH', 'equals', n_path)
                         .filterMetadata('WRS_ROW', 'equals', n_row)
                         .select([0,1,2,3,4,5,6,9], ["B","GR","R","NIR","SWIR_1","BRT","SWIR_2", "pixel_qa"])
-                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover));
+                        .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
+                        .map(set_landsat_index))
 
     return col_SR_L5;
 

--- a/etbrasil/geesebal/landsatcollection.py
+++ b/etbrasil/geesebal/landsatcollection.py
@@ -27,6 +27,40 @@ def set_landsat_index(img):
        by merging or joining collections"""
       return img.set({"LANDSAT_INDEX": img.get("system:index")})
 
+# Filter collection by path, row, and cloud cover
+def fexp_filter_PathRow(collection, start_date, end_date, n_path, n_row, th_cloud_cover):
+    return (collection
+            .filterDate(start_date, end_date)
+            .filterMetadata('WRS_PATH', 'equals', n_path)
+            .filterMetadata('WRS_ROW', 'equals', n_row)
+            .filterMetadata('CLOUD_COVER', 'less_than', th_cloud_cover)
+            )
+
+# GET T_RAD band from T1 products by PATH ROW
+def fexp_trad_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
+    return (fexp_filter_PathRow(
+        ee.ImageCollection('LANDSAT/LC08/C01/T1'),
+        start_date, end_date, n_path, n_row, th_cloud_cover)
+            .map(ee.Algorithms.Landsat.calibratedRadiance)
+            .map(set_landsat_index)
+            .select([9],["T_RAD"]))
+
+def fexp_trad_7PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
+    return (fexp_filter_PathRow(
+        ee.ImageCollection('LANDSAT/LE07/C01/T1'),
+        start_date, end_date, n_path, n_row, th_cloud_cover)
+            .map(ee.Algorithms.Landsat.calibratedRadiance)
+            .map(set_landsat_index)
+            .select([5],["T_RAD"]))
+
+def fexp_trad_5PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
+    return (fexp_filter_PathRow(
+        ee.ImageCollection('LANDSAT/LT05/C01/T1'),
+        start_date, end_date, n_path, n_row, th_cloud_cover)
+            .map(ee.Algorithms.Landsat.calibratedRadiance)
+            .map(set_landsat_index)
+            .select([5],["T_RAD"]))
+
 #GET LANDSAT 8 COLLECTIONS BY PATH ROW
 def fexp_landsat_8PathRow(start_date,end_date,n_path, n_row,th_cloud_cover):
     col_SR_L8 =(ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')

--- a/etbrasil/geesebal/timeseries.py
+++ b/etbrasil/geesebal/timeseries.py
@@ -23,7 +23,7 @@ from datetime import date
 import datetime
 
 #FOLDERS
-from .landsatcollection import fexp_landsat_5Coordinate, fexp_landsat_7Coordinate, fexp_landsat_8Coordinate
+from .landsatcollection import fexp_landsat_5, fexp_landsat_7, fexp_landsat_8
 from .masks import (f_cloudMaskL457_SR,f_cloudMaskL8_SR,f_albedoL5L7,f_albedoL8)
 from .meteorology import get_meteorology
 from .tools import (fexp_spec_ind, fexp_lst_export,fexp_radlong_up, LST_DEM_correction,
@@ -62,9 +62,9 @@ class TimeSeries():
         self.end_date = self.start_date.advance(self.n_search_days, 'day')
 
         #COLLECTIONS
-        self.collection_l5=fexp_landsat_5Coordinate(self.start_date, self.end_date, self.coordinate, self.cloud_cover)
-        self.collection_l7=fexp_landsat_7Coordinate(self.start_date, self.end_date, self.coordinate, self.cloud_cover)
-        self.collection_l8=fexp_landsat_8Coordinate(self.start_date, self.end_date, self.coordinate, self.cloud_cover)
+        self.collection_l5=fexp_landsat_5(self.start_date, self.end_date, self.cloud_cover, coordinate=self.coordinate)
+        self.collection_l7=fexp_landsat_7(self.start_date, self.end_date, self.cloud_cover, coordinate=self.coordinate)
+        self.collection_l8=fexp_landsat_8(self.start_date, self.end_date, self.cloud_cover, coordinate=self.coordinate)
 
         #LIST OF IMAGES
         self.sceneListL5 = self.collection_l5.aggregate_array('system:index').getInfo()

--- a/etbrasil/geesebal/timeseries.py
+++ b/etbrasil/geesebal/timeseries.py
@@ -63,10 +63,12 @@ class TimeSeriesAsync():
                  NDVI_cold=5,
                  Ts_cold=20,
                  NDVI_hot=10,
-                 Ts_hot=20):
+                 Ts_hot=20,
+                 max_iterations=15):
 
         geesebal_collection = Collection(year_i, month_i, day_i, year_e, month_e, day_e, cloud_cover,
-            coordinate=coordinate, NDVI_cold=NDVI_cold, Ts_cold=Ts_cold, NDVI_hot=NDVI_hot, Ts_hot = Ts_hot)
+            coordinate=coordinate, NDVI_cold=NDVI_cold, Ts_cold=Ts_cold, NDVI_hot=NDVI_hot, Ts_hot = Ts_hot, 
+            max_iterations=max_iterations)
         self.Collection = geesebal_collection
 
         et_collection = geesebal_collection.collection.select("ET_24h").map(

--- a/etbrasil/setup.py
+++ b/etbrasil/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(name = "geesebal")


### PR DESCRIPTION
Hi, I worked on a major, but purely technical, update to the geeSEBAL python API. That is, the revision to the code changes only the way in which geeSEBAL communicates with the earthengine API, and nothing was changed about the SEBAL algorithm. The goal was to [defer the GEE processing](https://developers.google.com/earth-engine/guides/deferred_execution) as much as possible (e.g. get rid of `.getInfo()`). The improvement in runtime highly outweighs some minor breaks in compatibility compared to the current version. 

Here's the breakdown of the changes:

## `tools.fexp_sensible_heat_flux`:

The iterative process was updated so that it leverages [ee.ImageCollection.iterate](https://developers.google.com/earth-engine/guides/ic_iterating). By doing this, and removing any `.getInfo()` calls, this function can be fully asynchronous (defers the execution until requested).

Additionally, a `max_iterations` (defaults to 15) parameter was added.

## `image.py`

Defined a new function `sebal` that constitutes the SEBAL algorithm to be applied over one `ee.Image`, assuming all the necessary inputs are included as bands within the image. 

## `Image` class

Revised the code so that it builds the `ee.Image` with all the Landsat inputs (including `T_RAD`) and then calls the `sebal` function.

Note that because I also removed the calls to `.getInfo()`, most items in the Image object are now deferred and thus return ee Objects. For example, `Image.landsat_version` now returns a `ee.String`. The user may use `.getInfo()` and get the result when needed. This is a break in compatibility that is justified, as the improvement in runtime far outweighs this disadvantage. 

### Runtime improvement for `Image`

Here's the comparison using [timeit](https://docs.python.org/3/library/timeit.html) on a simple instance of Image:

```python
%timeit foo=Image("LANDSAT/LC08/C01/T1_SR/LC08_221071_20190714")
```

serveronly branch:

```
25.2 ms ± 208 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

master branch:
```
12.7 s ± 1.97 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

i.e., 500 times faster. 

When used in a simple script that starts an Export task for a single ee.Image, the improvement is not as impressive (11s v 20s), because of the overhead of initializing the ee library, and creating the Export task. However, as you will see below, this will be much more important for Collection and TimeSeries. 

### Comparison 

The `LANDSAT/LC08/C01/T1_SR/LC08_221071_20190714` image was exported using the master and serveronly branches (only the R, GR, B, NDVI, and ET_24h bands were exported). They are publicly available here:

- [projects/geeet-public/assets/geesebal/LC08_221071_20190714_master](https://code.earthengine.google.com/?asset=projects/geeet-public/assets/geesebal/LC08_221071_20190714_master)
- [projects/geeet-public/assets/geesebal/LC08_221071_20190714_serveronly](https://code.earthengine.google.com/?asset=projects/geeet-public/assets/geesebal/LC08_221071_20190714_serveronly)

[This gee code snapshot](https://code.earthengine.google.com/ad16f154813f35fb49b426b02b210ca3) was prepared to compare the results, which are identical.

## `landsatcollection.py`

### Additions

`set_landsat_index`: This simple function is necessary to keep the original index from a Landsat image, when collections are merged or joined. 

`fexp_trad_8`, `fexp_trad_7`, and `fexp_trad_5`: These new functions return a `ee.ImageCollection` where each image has the corresponding `T_RAD` band. 

`fexp_collection_filter`: This new function handles filtering a given ee.ImageCollection by a user-defined cloud cover threshold, start and end dates, and optionally filtered by path, row, and a `ee.Geometry` (E.g. a coordinate). 

### Changes

All `fexp_landsat_NPathRow` and `fexp_landsat_NCoordinate` (where N is one of {5,7,8}) were replaced by a single `fexp_landsat_N` function. These functions return the corresponding `C01/T1_SR` collection filtered using `fexp_collection_filter`, and with the bands renamed as it was done in the original code. 

## `Collection` class

The init method for this class was modified to leverage the `fexp_landsat_N` and `fexp_trad_N` functions, which are then joined into a single collection using [ee.Join.inner](https://developers.google.com/earth-engine/apidocs/ee-join-inner). Furthermore, the python for loop was replaced by [ee.ImageCollection.map](https://developers.google.com/earth-engine/apidocs/ee-imagecollection-map), making use of the `image.sebal` function. 

For compatibility, the `Collection_ET` item is given as an ee.Image (the `ET_24h` collection is cast into ee.Image as bands). 
As was the case with the `Image` class, it was inevitable to break compatibility with some items in the `Collection` object. 

### Runtime improvement for `Collection` 

The following short test (3 images only) was used: 

```python
%timeit f=Collection(2019,7,1,2019,8,1,15,path=221,row=71)
```

serveronly branch:

```
87.4 ms ± 4.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

master branch: 

```
32.1 s ± 5.02 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

That is, 367 times faster. However, the time to generate a longer collection barely increases for the `serveronly` branch:

```
%timeit f=Collection(2000,1,1,2010,5,6,15,path=221,row=71)
```

```
87.1 ms ± 527 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

while for the master branch it does. For comparison, three images (only the ET_24h band) were exported using the master and serveronly branches. They are available in these image collections:

- [projects/geeet-public/assets/geesebal/master](https://code.earthengine.google.com/?asset=projects/geeet-public/assets/geesebal/master)
- [projects/geeet-public/assets/geesebal/serveronly](https://code.earthengine.google.com/?asset=projects/geeet-public/assets/geesebal/serveronly)

## `TimeseriesAsync`

The `TimeSeries` class was largely untouched (except minor adjustments to use the `fexp_landsat_N` functions. The reason for this was that I feel that the user would expect this function to simply get the time series, on-demand. However, a new `TimeSeriesAsync` class was defined. 

This new class makes use of the `Collection` class at a given point, then selects the `ET_24h` band and performs `reduceRegion` on it. The `et_collection` item contains the result of this operation, while the `Collection` items contains the result of the call to the `Collection` class. 

Additionally, three Lists were defined that somewhat mimics the behavior of the `TimeSeries` class. However, these are returned as `ee.Lists`, so the user has the option to use `.getInfo()` on them:

- `List_ET` is the result of `et_collection.aggregate_array("ET_24h")`
- `List_Date` is the result of `et_collection.aggregate_array("date")`
- `List_index` is the result of `et_collection.aggregate_array("LANDSAT_INDEX")`

Finally, two methods were prepared to export the ET table (date, LANDSAT_INDEX, ET_24h columns) as a CSV file. This should be the recommended way to export the table. 

- `toDrive`
- `toCloudStorage`

The following example demonstrates the use of `TimeSeriesAsync`:

```python
import ee
from etbrasil.geesebal import TimeSeriesAsync
ee.Initialize()
point=ee.Geometry.Point([-47.4522, -16.240119])
geesebal_timeseries=TimeSeriesAsync(2000,1,1,2010,5,6,15,coordinate=point)
geesebal_timeseries.toDrive("sebal-time-series-async")  
```

This generates a `sebal-time-series-async.csv` file in Google Drive. The total process (python runtime + earthengine task) took about 2 minutes. 

The following example generates the same csv file but synchronously (note the `getInfo()`s):

```python
import pandas as pd
import ee
from etbrasil.geesebal import TimeSeriesAsync
ee.Initialize()
point=ee.Geometry.Point([-47.4522, -16.240119])
geesebal_timeseries=TimeSeriesAsync(2000,1,1,2010,5,6,15,coordinate=point)

et_list = geesebal_timeseries.List_ET.getInfo()       
date_list = geesebal_timeseries.List_Date.getInfo()  
landsat_index_list = geesebal_timeseries.List_index.getInfo() 

pd.DataFrame({
    "date": date_list,
    "LANDSAT_INDEX": landsat_index_list,
    "ET_24h": et_list
}).to_csv("sebal-time-series-sync.csv", index=False)
```

This example took about 3 minutes to run, and the resulting csv file was identical to the previous one. 

However, the preferred method should be the asynchronous one, especially for long collections, as described [here](https://developers.google.com/earth-engine/guides/debugging#too-many) ("Too many concurrent aggregations" error). 

As was the case for `Collection`, the `TimeSeriesAsync` runtime is fast and does not depend on the image collection size. Here is my result using `timeit`:

```
90.3 ms ± 431 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Meanwhile, the current version of geesebal took about 25 minutes ⚠️ on this rather short test (19 images):

```
from etbrasil.geesebal import TimeSeries
point=ee.Geometry.Point([-50.161317, -9.824870])
geeSEBAL_Collection=TimeSeries(2019,1,1,2019,12,31,15,point)
```

That is all for now, I hope I haven't missed anything to describe from my changes, and that my explanations were clear.

Cheers, 

Oliver.

